### PR TITLE
[DK-822] Feature/immediate write

### DIFF
--- a/c/crecordio.go
+++ b/c/crecordio.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"unsafe"
 
-	"github.com/PaddlePaddle/recordio"
+	"github.com/visenze/recordio"
 )
 
 var nullPtr = unsafe.Pointer(uintptr(0))

--- a/python/docker_build.sh
+++ b/python/docker_build.sh
@@ -1,0 +1,16 @@
+#! /bin/bash
+BUILD_IMAGE="visenze/golang:1.10"
+
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+REPO_ROOT=$(dirname "$SCRIPT_DIR")
+
+CONTAINER_REPO_ROOT="/go/src/github.com/visenze/recordio"
+echo "executing $SCRIPT_DIR/docker_build.sh"
+echo "repo root = $REPO_ROOT"
+
+echo "mounting $REPO_ROOT --> $CONTAINER_REPO_ROOT"
+
+docker run --rm -it\
+    -v "$REPO_ROOT":"$CONTAINER_REPO_ROOT" \
+    -w "$CONTAINER_REPO_ROOT" \
+    "$BUILD_IMAGE" bash  -c "dep init 2>/dev/null; cd python && ./build.sh"

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,20 +1,20 @@
 from setuptools import setup, Distribution
 
+
 class BinaryDistribution(Distribution):
     def has_ext_modules(foo):
         return True
 
+
 setup(
-    name='visenze_recordio',
-    version='0.2',
-    description='An implementation of the RecordIO file format.',
-    url='https://github.com/PaddlePaddle/recordio',
-    author='PaddlePaddle Authors',
-    author_email='paddle-dev@baidu.com',
-    license='Apache 2.0',
-    packages=['recordio'],
-    package_data={
-        'recordio': ['librecordio.so'],
-    },
-    distclass=BinaryDistribution
+    name="visenze_recordio",
+    version="0.3",
+    description="An implementation of the RecordIO file format.",
+    url="https://github.com/PaddlePaddle/recordio",
+    author="PaddlePaddle Authors",
+    author_email="paddle-dev@baidu.com",
+    license="Apache 2.0",
+    packages=["recordio"],
+    package_data={"recordio": ["librecordio.so"],},
+    distclass=BinaryDistribution,
 )

--- a/recordio_test.go
+++ b/recordio_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/PaddlePaddle/recordio"
+	"github.com/visenze/recordio"
 )
 
 func ExampleWriter_Write() {

--- a/writer.go
+++ b/writer.go
@@ -42,13 +42,13 @@ func (w *Writer) Write(record []byte) (int, error) {
 		return 0, fmt.Errorf("Cannot write since writer had been closed")
 	}
 
-	if w.chunk.numBytes+len(record) > w.maxChunkSize {
+	w.chunk.add(record)
+	if w.chunk.numBytes > w.maxChunkSize {
 		if e := w.chunk.dump(w.Writer, w.compressor); e != nil {
 			return 0, e
 		}
 	}
 
-	w.chunk.add(record)
 	return len(record), nil
 }
 


### PR DESCRIPTION
### Description
The old implementation always delays the writing of a newly added record even when the `maxChunkSize` is less than the size of the record.
This PR modifies the behaviors, to always add the new record to the buffer, then flush the buffer if necessary. This way, when `maxChunkSize` is less than record size, the new record will always be written immediately